### PR TITLE
Feature: New Server added (Caddy v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Sephiroth is made to help block clouds.
 
 options:
   -h, --help            show this help message and exit
-  -s {nginx,apache,iptables,ip6tables}, --server {nginx,apache,iptables,ip6tables}
+  -s {nginx,apache,caddy,iptables,ip6tables}, --server {nginx,apache,caddy,iptables,ip6tables}
                         Type of server to build blocklist for
   -t {aws,azure,gcp,oci,asn,file,tor,do,linode,cloudflare}, --target {aws,azure,gcp,oci,asn,file,tor,do,linode,cloudflare}
                         Targets to block
@@ -100,6 +100,7 @@ Then you can use the $block_ip variable in your site config like so:
 
 * `nginx` - Makes use of nginx's `ngx_http_geo_module` which comes with the nginx package in Ubuntu 18.04. Optionally supports the use of `proxy_protocol`, in the event that you are using a PROXY-enabled redirector.
 * `apache` - Generates a mod_rewrite rule set to do conditional redirects based on cloud ip ranges. Does not (to my knowledge) support `proxy_protocol` usage. Requires `-r REDIR_TARGET` for the RewriteRule
+* `caddy` - Generates a list of IP addresses, each prepended with the `remote_ip` request matcher.
 * `iptables` - Generates a set of iptables DROP rules to block access from listed IPv4 ranges.
 * `ip6tables` - Generates a set of ip6tables DROP rules to block access from listed IPv6 ranges.
 

--- a/Sephiroth.py
+++ b/Sephiroth.py
@@ -12,7 +12,7 @@ from sephiroth.providers import Provider
 from sephiroth.providers.provider import classmap as supported_targets
 import sephiroth
 
-supported_servers = ["nginx", "apache", "iptables", "ip6tables"]
+supported_servers = ["nginx", "apache", "caddy", "iptables", "ip6tables"]
 
 base_dir = os.path.dirname(__file__)
 template_dir = os.path.join(base_dir, "sephiroth", "templates")
@@ -103,6 +103,14 @@ def validate_apache_args(args):
             "[!] Error: Redirect target should not include scheme. Please edit the output RewriteRule directly if you want to change this."
         )
         raise SystemExit
+    return True
+
+
+def validate_caddy_args(args):
+    if args.redir_target:
+        print(
+            "[?] Warning: We cannot generate caddy configs with redirect targets at this time. Ignoring."
+        )
     return True
 
 
@@ -209,6 +217,7 @@ def validate_targets(args):
 server_validators = {
     "apache": validate_apache_args,
     "nginx": validate_nginx_args,
+    "caddy": validate_caddy_args,
     "iptables": validate_iptables_args,
     "ip6tables": validate_ip6tables_args,
 }

--- a/sephiroth/templates/caddy/conf.jinja
+++ b/sephiroth/templates/caddy/conf.jinja
@@ -1,0 +1,8 @@
+# Built by Sephiroth on {{ build_date }} (UTC)
+{% for comment in header_comments -%}
+# {{ comment }}
+{% endfor %}
+
+{% for range in ranges -%}
+{% if loop.last %}# (For the below line) {{ range.comment + '\n' }}{% endif %} remote_ip {{ range.range }} {% if not loop.last %} # {{ range.comment }}{% endif %}
+{% endfor %}

--- a/sephiroth/templates/caddy/help.jinja
+++ b/sephiroth/templates/caddy/help.jinja
@@ -1,0 +1,34 @@
+In your Caddyfile (or in a separate file that you want to import), define a matcher to block the list of IP addresses:
+    
+    @ip_blocklist {
+        import {{ abspath }}
+    }
+
+Then you can use the request matcher like this:
+
+    route @ip_blocklist {
+        redir https://example.com
+    }
+
+Usage example:
+
+mydomain.com {
+
+    handle * {
+        @ip_blocklist {
+            import {{ abspath }}
+        }
+
+        route @ip_blocklist {
+            redir https://example.com
+        }
+    }
+
+    log {
+        output file access.log {
+            roll true
+            roll_size_mb 10
+            roll_keep 2
+        }
+    }
+}

--- a/sephiroth/templates/caddy1/conf.jinja
+++ b/sephiroth/templates/caddy1/conf.jinja
@@ -1,5 +1,0 @@
-ipfilter / {
-    rule block
-    {% for range in ranges -%}
-    ip {{ range.range }}
-}


### PR DESCRIPTION
- Added caddy as a server + template and working example of how to use it in `help.jinja`.
- ~Added `requirements.txt` so that one can use Sephiroth with the more common `pip install -r requirements.txt` but retaining the advice to use a virtual environment using `python3 -m venv venv` instead of `pipenv`.~

## Summary by Sourcery

~Add support for Caddy v2 and introduce a `requirements.txt` file. Update the documentation to reflect these changes.~

New Features:
- Add Caddy v2 as a supported server for generating blocklists.
- ~Introduce a `requirements.txt` file for easier dependency management using `pip` within a virtual environment~

Documentation:
- ~Document how to install Sephiroth using `requirements.txt` and a virtual environment.~
- Add documentation for the Caddy v2 server configuration and usage in `help.jinja` template.
- Update the help message to include `caddy` as a supported server type.
- Update the README ~with instructions for installing requirements from a `requirements.txt` file using a virtual environment and~ with information about caddy support. 