### PR TITLE
feat: added remote_file provider

### DIFF
--- a/src/sephiroth/providers/__init__.py
+++ b/src/sephiroth/providers/__init__.py
@@ -6,6 +6,7 @@ from sephiroth.providers.azure import Azure
 from sephiroth.providers.cloudflare import Cloudflare
 from sephiroth.providers.do import DO
 from sephiroth.providers.file import File
+from sephiroth.providers.remote_file import RemoteFile
 from sephiroth.providers.gcp import GCP
 from sephiroth.providers.linode import Linode
 from sephiroth.providers.oci import OCI
@@ -19,6 +20,7 @@ classmap = {
     "oci": OCI,
     "asn": ASN,
     "file": File,
+    "remote-file": RemoteFile,
     "tor": Tor,
     "do": DO,
     "linode": Linode,

--- a/src/sephiroth/providers/remote_file.py
+++ b/src/sephiroth/providers/remote_file.py
@@ -1,0 +1,45 @@
+import requests
+from sephiroth.providers.base_provider import BaseProvider
+
+class RemoteFile(BaseProvider):
+    def __init__(self, urls: list[str], excludeip6: bool = False):
+        self.urls = urls
+        self.excludeip6 = excludeip6
+        self.source_ranges = self._get_ranges()
+        self.processed_ranges = self._process_ranges()
+
+    def _get_ranges(self) -> dict:
+        ranges = {}
+        for url in self.urls:
+            try:
+                resp = requests.get(url)
+                resp.raise_for_status()
+                lines = resp.text.splitlines()
+                ranges[url] = [line + "\n" for line in lines]
+            except Exception as e:
+                print(f"[!] Failed to fetch {url}: {e}")
+        return ranges
+
+    def _process_ranges(self) -> dict:
+        ranges = []
+        for fname, range_list in self.source_ranges.items():
+            for ip_line in range_list:
+                if ip_line.startswith("#"):
+                    continue
+                if ":" in ip_line and self.excludeip6:
+                    continue
+                if "#" in ip_line:
+                    ip_addr, comment = map(str.strip, ip_line.split("#", 1))
+                else:
+                    ip_addr = ip_line.strip()
+                    comment = ""
+                ranges.append({
+                    "range": ip_addr,
+                    "comment": f"{fname} {comment}".strip()
+                })
+
+        return {
+            "header_comments": [f"(remote-file) Fetched from {', '.join(self.urls)}"],
+            "ranges": ranges
+        }
+


### PR DESCRIPTION
Hi, I'd like to be able to give some remote files that are constantly updated as source of IPs to block (i.e. https://github.com/X4BNet/lists_vpn/tree/main/output) so I implemented these changes to be able to do so. This works if you use  it like this `-t remote-file https://xyz.com/ip-list.txt` but also like this `-t _all --url https://xyz.com/ip-list.txt`. Multiple `--url` flag are supported so sources are fetched and merged in a single file as with the use of the `file` flag.

## Summary by Sourcery

Add a remote-file provider to allow fetching IP lists from remote URLs, extend CLI to accept --url flags, and integrate it into the existing target processing flow.

New Features:
- Add remote-file provider to fetch and merge IP ranges from one or more URLs
- Introduce -u/--url CLI option that supports multiple URLs and validate its usage

Enhancements:
- Integrate remote-file target into main loop with unified provider_vars handling and support for _all meta target
- Register RemoteFile class in the provider mapping